### PR TITLE
Fix Nintendo button prompts

### DIFF
--- a/ControllerFixes/ControllerFixes.cs
+++ b/ControllerFixes/ControllerFixes.cs
@@ -204,7 +204,7 @@ public class ControllerFixes : Mod, IGlobalSettings<GlobalSettings>, ICustomMenu
 				        {
 					        Sprite[] array9 = new Sprite[]
 					        {
-						        settings.SteamNintendoLayout ? uIButtonSkins.switchHidA : uIButtonSkins.switchHidB,
+						        settings.SteamNintendoLayout ? uIButtonSkins.switchHidB : uIButtonSkins.switchHidA,
 						        uIButtonSkins.ps4x,
 						        uIButtonSkins.a,
 					        };
@@ -215,7 +215,7 @@ public class ControllerFixes : Mod, IGlobalSettings<GlobalSettings>, ICustomMenu
 				        {
 					        Sprite[] array10 = new Sprite[]
 					        {
-						        settings.SteamNintendoLayout ? uIButtonSkins.switchHidB : uIButtonSkins.switchHidA,
+						        settings.SteamNintendoLayout ? uIButtonSkins.switchHidA : uIButtonSkins.switchHidB,
 						        uIButtonSkins.ps4circle,
 						        uIButtonSkins.b,
 					        };


### PR DESCRIPTION
Fixes #1, Nintendo Skin Type (number 1) no longer switches the A and B buttons.